### PR TITLE
kde-cp replaced with kdecp5

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -108,8 +108,8 @@ if $RootInstall ; then
         mk_directory $pathExec
 
         rm "$pathService/$foldercolorSH" "$pathService/$foldercolorDE"
-        kde-cp --overwrite ./$foldercolorSH "$pathExec/$foldercolorSH"
-        kde-cp --overwrite ./$tmp           "$pathService/$foldercolorDE"
+        kdecp5 --overwrite ./$foldercolorSH "$pathExec/$foldercolorSH"
+        kdecp5 --overwrite ./$tmp           "$pathService/$foldercolorDE"
 
         if [ $? != 0 ] ; then
             succesInstall=false
@@ -135,8 +135,8 @@ else
     mk_directory $pathService
     
     rm "$pathService/$foldercolorSH" "$pathService/$foldercolorDE"
-    kde-cp --overwrite ./$foldercolorSH "$pathService/$foldercolorSH"
-    kde-cp --overwrite ./$tmp           "$pathService/$foldercolorDE"
+    kdecp5 --overwrite ./$foldercolorSH "$pathService/$foldercolorSH"
+    kdecp5 --overwrite ./$tmp           "$pathService/$foldercolorDE"
     if [[ $? != 0 ]] ; then
         succesInstall=false
     fi


### PR DESCRIPTION
`kde-cp` doesn't work anymore with newer versions of KDE, one of the reasons I encountered are because newer versions of KDE doesn't allow usage of `kdesu` anymore. Replacing it with `kdecp5` fixed the issue.

This pull request will fix [this](https://forum.manjaro.org/t/change-kde-desktop-dolphin-folder-colors-or-colours/43721) and #10 issue.